### PR TITLE
Fix `unused_must_use` lint when used with async fns

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,7 +13,7 @@ description = "Parameterized test cases and test decorators"
 
 [dependencies]
 once_cell = { workspace = true, optional = true }
-test-casing-macro = { version = "0.1.0", path = "../macro" }
+test-casing-macro = { version = "=0.1.1", path = "../macro" }
 
 [dev-dependencies]
 async-std.workspace = true

--- a/lib/tests/integration/test_casing.rs
+++ b/lib/tests/integration/test_casing.rs
@@ -77,6 +77,15 @@ const STRING_CASES: TestCases<(String, i32)> = cases!((0..5).map(|i| (i.to_strin
 
 #[test_casing(5, STRING_CASES)]
 #[async_std::test]
+async fn async_string_conversion_without_output(#[map(ref)] s: &str, expected: i32) {
+    let actual: i32 = s.parse().unwrap();
+    assert_eq!(actual, expected);
+    let expected_string = task::spawn_blocking(move || expected.to_string()).await;
+    assert_eq!(expected_string, s);
+}
+
+#[test_casing(5, STRING_CASES)]
+#[async_std::test]
 async fn async_string_conversion(#[map(ref)] s: &str, expected: i32) -> Result<(), Box<dyn Error>> {
     let actual: i32 = s.parse()?;
     assert_eq!(actual, expected);

--- a/macro/src/test_casing/mod.rs
+++ b/macro/src/test_casing/mod.rs
@@ -245,9 +245,9 @@ impl FunctionWrapper {
         let name = &self.name;
         let cases_expr = &self.attrs.expr;
         let (case_binding, case_args) = self.case_binding();
-        let maybe_output_binding = match &self.fn_sig.output {
-            ReturnType::Default => None,
-            ReturnType::Type(..) => Some(quote!(let _ = )),
+        let maybe_output_binding = match (&self.fn_sig.asyncness, &self.fn_sig.output) {
+            (None, ReturnType::Default) => None,
+            _ => Some(quote!(let _ = )),
         };
         // ^ Using `let _ = ` on the `()` return type triggers https://rust-lang.github.io/rust-clippy/master/index.html#/ignored_unit_patterns
         // in Rust 1.73+.


### PR DESCRIPTION
## What?

Changes in #14 have backfired for async fns without an explicit return type; they now trigger `unused_must_use` lint. This PR fixes generated code in this case.

## Why?

See above.