### PR TITLE
Prepare 0.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.1.2 - 2023-11-02
+
+### Fixed
+
+- Fix `unused_must_use` lint triggered for async functions without the explicit
+  return value after the previous fix.
+- Pin a version of the macro dependency in the main library so that it does not break
+  in the future releases.
+
 ## 0.1.1 - 2023-10-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "test-casing"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-std",
  "doc-comment",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "test-casing-macro"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_matches",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["lib", "macro"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.65"
 authors = ["Alex Ostrovski <ostrovski.alex@gmail.com>"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,7 +13,7 @@ description = "Parameterized test cases and test decorators"
 
 [dependencies]
 once_cell = { workspace = true, optional = true }
-test-casing-macro = { version = "=0.1.1", path = "../macro" }
+test-casing-macro = { version = "=0.1.2", path = "../macro" }
 
 [dev-dependencies]
 async-std.workspace = true

--- a/lib/README.md
+++ b/lib/README.md
@@ -25,7 +25,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dev-dependencies]
-test-casing = "0.1.1"
+test-casing = "0.1.2"
 ```
 
 ### Examples: test cases

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -109,7 +109,7 @@
 
 #![cfg_attr(feature = "nightly", feature(custom_test_frameworks, test))]
 // Documentation settings
-#![doc(html_root_url = "https://docs.rs/test-casing/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/test-casing/0.1.2")]
 // Linter settings
 #![warn(missing_debug_implementations, missing_docs, bare_trait_objects)]
 #![warn(clippy::all, clippy::pedantic)]

--- a/macro/README.md
+++ b/macro/README.md
@@ -16,7 +16,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dev-dependencies]
-test-casing-macro = "0.1.1"
+test-casing-macro = "0.1.2"
 ```
 
 Note that the `test-casing` crate re-exports the proc macros from this crate. 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -8,7 +8,7 @@
 //! [`test-casing`]: https://docs.rs/test-casing/
 
 // Documentation settings
-#![doc(html_root_url = "https://docs.rs/test-casing-macro/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/test-casing-macro/0.1.2")]
 // Linter settings
 #![warn(missing_debug_implementations, bare_trait_objects)]
 #![warn(clippy::all, clippy::pedantic)]


### PR DESCRIPTION
## What?

Prepares the next crates release (0.1.2).

## Why?

The 0.1.1 release turned out to have a bug; it triggers `unused_must_use` lint for async functions without the explicit return value.