### PR TITLE
Fix clippy warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -23,7 +23,7 @@ jobs:
           toolchain: ${{ env.msrv }}
 
       - name: Cache cargo build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: ${{ runner.os }}-msrv-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -46,13 +46,13 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
       - name: Install cargo-deny
-        uses: baptiste0928/cargo-install@v2
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-deny
           version: "^0.14"
 
       - name: Cache cargo build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -83,7 +83,7 @@ jobs:
           components: clippy
 
       - name: Cache cargo build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: ${{ runner.os }}-nightly-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -114,7 +114,7 @@ jobs:
           toolchain: ${{ env.nightly }}
 
       - name: Cache cargo build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: ${{ runner.os }}-document-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `clippy::no_effect_underscore_binding` lint triggered by the generated code in Rust 1.76+.
+
 ## 0.1.2 - 2023-11-02
 
 ### Fixed

--- a/lib/tests/integration/decorate.rs
+++ b/lib/tests/integration/decorate.rs
@@ -36,9 +36,10 @@ fn with_mixed_decorators() {
 fn with_retries() {
     static COUNTER: AtomicU32 = AtomicU32::new(0);
 
-    if COUNTER.fetch_add(1, Ordering::Relaxed) == 0 {
-        panic!("Sometimes we all fail");
-    }
+    assert!(
+        COUNTER.fetch_add(1, Ordering::Relaxed) != 0,
+        "Sometimes we all fail"
+    );
 }
 
 #[test]
@@ -147,9 +148,7 @@ impl SequenceChecker {
 
     fn start(&self) -> SequenceCheckerGuard<'_> {
         let prev_value = self.is_running.swap(true, Ordering::SeqCst);
-        if prev_value {
-            panic!("Sequential tests are not sequential!");
-        }
+        assert!(!prev_value, "Sequential tests are not sequential!");
         SequenceCheckerGuard {
             is_running: &self.is_running,
         }

--- a/lib/tests/integration/main.rs
+++ b/lib/tests/integration/main.rs
@@ -1,6 +1,9 @@
 //! Integration tests for crate functionality.
 
 #![cfg_attr(feature = "nightly", feature(test, custom_test_frameworks))]
+// Enable additional lints to ensure that the code produced by the macro doesn't raise warnings.
+#![warn(missing_debug_implementations, missing_docs, bare_trait_objects)]
+#![warn(clippy::all, clippy::pedantic)]
 
 mod decorate;
 mod test_casing;

--- a/macro/src/test_casing/mod.rs
+++ b/macro/src/test_casing/mod.rs
@@ -254,7 +254,7 @@ impl FunctionWrapper {
 
         quote! {
             const _: () = {
-                #[allow(dead_code)]
+                #[allow(dead_code, clippy::no_effect_underscore_binding)]
                 fn __test_cases_iterator() {
                     let #case_binding = #cr::case(#cases_expr, 0);
                     #maybe_output_binding #name(#case_args);
@@ -275,6 +275,9 @@ impl FunctionWrapper {
             #test_cases_iter
 
             #[cfg(test)]
+            #[allow(clippy::no_effect_underscore_binding)]
+            // ^ We use `__ident`s to not alias user-defined idents accidentally. Unfortunately,
+            // this triggers this lint on Rust 1.76+.
             mod #name {
                 use super::*;
                 #arg_names


### PR DESCRIPTION
## What?

Fixes `clippy::no_effect_underscore_binding` lint triggered by the generated code in Rust 1.76+.

## Why?

Having warnings produced by the generated code is obviously bad.