### PR TITLE
Prepare 0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.1.3 - 2024-03-03
+
 ### Fixed
 
 - Fix `clippy::no_effect_underscore_binding` lint triggered by the generated code in Rust 1.76+.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "test-casing"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-std",
  "doc-comment",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "test-casing-macro"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "assert_matches",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ members = ["lib", "macro"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+# **NB.** `test-casing-macro` dependency version must be bumped in the `test-casing` manifest
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.65"
 authors = ["Alex Ostrovski <ostrovski.alex@gmail.com>"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,7 +13,7 @@ description = "Parameterized test cases and test decorators"
 
 [dependencies]
 once_cell = { workspace = true, optional = true }
-test-casing-macro = { version = "=0.1.2", path = "../macro" }
+test-casing-macro = { version = "=0.1.3", path = "../macro" }
 
 [dev-dependencies]
 async-std.workspace = true

--- a/lib/README.md
+++ b/lib/README.md
@@ -25,7 +25,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dev-dependencies]
-test-casing = "0.1.2"
+test-casing = "0.1.3"
 ```
 
 ### Examples: test cases

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -109,7 +109,7 @@
 
 #![cfg_attr(feature = "nightly", feature(custom_test_frameworks, test))]
 // Documentation settings
-#![doc(html_root_url = "https://docs.rs/test-casing/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/test-casing/0.1.3")]
 // Linter settings
 #![warn(missing_debug_implementations, missing_docs, bare_trait_objects)]
 #![warn(clippy::all, clippy::pedantic)]

--- a/macro/README.md
+++ b/macro/README.md
@@ -16,7 +16,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dev-dependencies]
-test-casing-macro = "0.1.2"
+test-casing-macro = "0.1.3"
 ```
 
 Note that the `test-casing` crate re-exports the proc macros from this crate. 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -8,7 +8,7 @@
 //! [`test-casing`]: https://docs.rs/test-casing/
 
 // Documentation settings
-#![doc(html_root_url = "https://docs.rs/test-casing-macro/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/test-casing-macro/0.1.3")]
 // Linter settings
 #![warn(missing_debug_implementations, bare_trait_objects)]
 #![warn(clippy::all, clippy::pedantic)]


### PR DESCRIPTION
## What?

Prepares the next release (0.1.3).

## Why?

The published version will include a fix for the `clippy::no_effect_underscore_binding` lint triggered in Rust 1.76+.