### PR TITLE
chore: Bump crate version to 0.2.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.2.0-beta.1 - 2026-02-01
+
 ### Added
 
 - Assert the test case count in a separate generated test. This protects against the scenario in which

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "test-casing"
-version = "0.1.3"
+version = "0.2.0-beta.1"
 dependencies = [
  "doc-comment",
  "once_cell",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "test-casing-macro"
-version = "0.1.3"
+version = "0.2.0-beta.1"
 dependencies = [
  "assert_matches",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["lib", "macro"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3"
+version = "0.2.0-beta.1"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Alex Ostrovski <ostrovski.alex@gmail.com>"]
@@ -28,7 +28,7 @@ version-sync = "0.9.4"
 
 # Workspace dependencies
 # We use the exact version to not bother with compatibility of internal items used by proc macros.
-test-casing-macro = { version = "=0.1.3", path = "macro" }
+test-casing-macro = { version = "=0.2.0-beta.1", path = "macro" }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/lib/README.md
+++ b/lib/README.md
@@ -25,7 +25,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dev-dependencies]
-test-casing = "0.1.3"
+test-casing = "0.2.0-beta.1"
 ```
 
 ### Examples: test cases

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -117,7 +117,7 @@
 #![cfg_attr(feature = "nightly", feature(custom_test_frameworks, test))]
 // Documentation settings
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/test-casing/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/test-casing/0.2.0-beta.1")]
 
 /// Wraps a tested function to add retries, timeouts etc.
 ///

--- a/macro/README.md
+++ b/macro/README.md
@@ -16,7 +16,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dev-dependencies]
-test-casing-macro = "0.1.3"
+test-casing-macro = "0.2.0-beta.1"
 ```
 
 Note that the `test-casing` crate re-exports the proc macros from this crate. 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -8,7 +8,7 @@
 //! [`test-casing`]: https://docs.rs/test-casing/
 
 // Documentation settings
-#![doc(html_root_url = "https://docs.rs/test-casing-macro/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/test-casing-macro/0.2.0-beta.1")]
 #![allow(missing_docs)] // The macros are documented in the main crate
 
 extern crate proc_macro;


### PR DESCRIPTION
## What?

Prepares the new crate release.

## Why?

There's significant new functionality (the `tracing` feature).
